### PR TITLE
Handle prepare layout like adventure cards

### DIFF
--- a/src/AuditDownloader.py
+++ b/src/AuditDownloader.py
@@ -265,7 +265,7 @@ def build_candidate_entries_for_card(card: dict) -> List[dict]:
                 entries.append({"url": u, "rotate": None, "candidates": cands, "ext": ext, "card": card})
                 return entries
 
-        if layout == "adventure":
+        if layout in {"adventure", "prepare"}:
             faces = card.get("card_faces") or []
             if faces:
                 cf = _concat_faces(faces, "flavor_name")

--- a/src/Downloader.py
+++ b/src/Downloader.py
@@ -405,7 +405,7 @@ def display_name_for_single_image(card: dict) -> str:
     Single-image cases:
       - Split / Aftermath: concatenates both face names without spaces
         (e.g., "AssaultBattery")
-      - Adventure: uses ONLY the primary face name (faces[0])
+      - Adventure / Prepare: uses ONLY the primary face name (faces[0])
       - All other single-face cards: uses card["name"]
     """
     layout = (card.get("layout") or "").lower()
@@ -415,7 +415,7 @@ def display_name_for_single_image(card: dict) -> str:
             combined = "".join((f.get("name") or "").replace(" ", "") for f in faces).strip()
             if combined:
                 return combined
-    if layout == "adventure":
+    if layout in {"adventure", "prepare"}:
         faces = card.get("card_faces") or []
         if faces and (faces[0].get("name") or "").strip():
             return faces[0]["name"].strip()
@@ -432,6 +432,7 @@ def pick_image_entries(card: dict) -> List[ImgEntry]:
       - image_uris:
           * split/aftermath -> 1 file with concatenated name
           * flip -> 2 files: Face1 normal, Face2 rotated 180°
+          * adventure/prepare -> 1 file with the primary face name
           * others -> 1 file with card['name']
       - card_faces with image_uris -> 1 file per face (DFC etc.)
     """
@@ -453,8 +454,11 @@ def pick_image_entries(card: dict) -> List[ImgEntry]:
             entries.append(ImgEntry(u, name, None))
             return entries
         
-        if layout == "adventure":
-            name = display_name_for_single_image(card)  # Main Face
+        if layout in {"adventure", "prepare"}:
+            # Both layouts are one physical card image. Scryfall's card name
+            # contains "Main Face // inset spell", whereas Forge keys the
+            # image by the main permanent's name.
+            name = display_name_for_single_image(card)
             entries.append(ImgEntry(u, name, None))
             return entries
 

--- a/src/SingleCard.py
+++ b/src/SingleCard.py
@@ -310,7 +310,7 @@ def singlecard_intro_box(out_dir: Path):
 def canonical_single_name(card: dict) -> str:
     """
     Nome canônico para cartas de UMA imagem:
-      - adventure: usar a face principal (faces[0].name)
+      - adventure/prepare: usar a face principal (faces[0].name)
         * detecta por layout OU pela estrutura das faces (Instant/Sorcery 'Adventure')
       - demais: card['name']
     """
@@ -318,8 +318,8 @@ def canonical_single_name(card: dict) -> str:
     layout = (card.get("layout") or "").lower()
     faces = card.get("card_faces") or []
 
-    # 1) Se o layout já disser 'adventure', usamos face[0]
-    if layout == "adventure" and faces and (faces[0].get("name") or "").strip():
+    # 1) Se o layout já disser 'adventure' ou 'prepare', usamos face[0]
+    if layout in {"adventure", "prepare"} and faces and (faces[0].get("name") or "").strip():
         return faces[0]["name"].strip()
 
     # 2) Fallback robusto: detectar adventure pela estrutura das faces

--- a/src/fast_csv_set.py
+++ b/src/fast_csv_set.py
@@ -146,7 +146,7 @@ def canonical_name_for_single_image(card: dict) -> str:
     """
     Keep close to your existing behavior:
     - split/aftermath -> concat face names without spaces
-    - adventure -> use face[0]
+    - adventure/prepare -> use face[0]
     - otherwise -> card['name']
     """
     layout = (card.get("layout") or "").lower()
@@ -156,7 +156,7 @@ def canonical_name_for_single_image(card: dict) -> str:
             combined = "".join((f.get("name") or "").replace(" ", "") for f in faces).strip()
             if combined:
                 return combined
-    if layout == "adventure":
+    if layout in {"adventure", "prepare"}:
         faces = card.get("card_faces") or []
         if faces and (faces[0].get("name") or "").strip():
             return faces[0]["name"].strip()
@@ -187,7 +187,7 @@ def pick_image_entries(card: dict) -> List[Tuple[str, str, int, str]]:
             out.append((u, nm, 1, "h90"))  # rotate only if needed (optional)
             return out
 
-        if layout == "adventure":
+        if layout in {"adventure", "prepare"}:
             nm = canonical_name_for_single_image(card)
             out.append((u, nm, 1, ""))
             return out


### PR DESCRIPTION
## What does this PR do?
Treat `prepare` cards the same as `adventure` when selecting single-image filenames. This uses the primary face name for both layouts (instead of the full `Name // Name` string), matching Forge’s image key expectations and clarifying behavior in the related docstrings/comments.

## Why is this change needed?
Bug fix - Scryfall's file naming system for cards with prepared spells did not match Forge's expected naming convention, Causing the files to not be recognized.

## Scope of changes
- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other (explain below)

## Impact
This PR extends the handling of Adventure cards to Cards with Prepared spell

## Tested?
- [X] Yes — tested locally
- [ ] Partially
- [ ] No